### PR TITLE
Default mock behavior is not respected (when Strict)

### DIFF
--- a/src/stashbox.mocking.moq/StashMoq.cs
+++ b/src/stashbox.mocking.moq/StashMoq.cs
@@ -30,7 +30,7 @@ namespace Stashbox.Mocking.Moq
         /// <param name="verifyAll">If true the disposal of this object will trigger a .VerifyAll() on the mock repository.</param>
         /// <returns>The <see cref="StashMoq"/> instance.</returns>
         public static StashMoq Create(MockBehavior behavior = MockBehavior.Default, bool verifyAll = false) =>
-            new StashMoq(new MockRepository(MockBehavior.Default), behavior, verifyAll);
+            new StashMoq(new MockRepository(behavior), behavior, verifyAll);
 
         /// <summary>
         /// Creates a mock object and registers it into the container.


### PR DESCRIPTION
If a mock is resolved prior to being configured (aka: before using the Mock<T>() function), its behavior will be the behavior of the MockRepository (which in that case, was hard-coded to "MockBehavior.Default").
The MockBehavior should be built with the default behavior passed to the "Create()" method.